### PR TITLE
Issue #2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,10 @@
     {
       "name": "Nikita Morozov",
       "email": "morozov.nikita@itmh.ru"
+    },
+    {
+      "name": "Busygin Alexander",
+      "email": "busygin.aleksandr@itmh.ru"
     }
   ],
   "require": {

--- a/src/ITMH/ServiceTools/Core/Response.php
+++ b/src/ITMH/ServiceTools/Core/Response.php
@@ -6,6 +6,7 @@ use ErrorException;
 
 /**
  * Class Response
+ *
  * @package ITMH\ServiceTools\Core
  */
 class Response
@@ -31,25 +32,35 @@ class Response
      *
      * @var string
      */
-    private $error;
+    private $errorMessage;
+
+    /**
+     * Код ошибки в текстовом представлении
+     *
+     * @var string
+     */
+    private $errorCode;
 
     /**
      * Конструктор экземпляра, используется только во вспомогательных методах
      *
-     * @param bool   $isSuccess Флаг успешности
-     * @param mixed  $body      Содержимое ответа ответа
-     * @param string $error     Строка с описанием ошибки
+     * @param bool   $isSuccess    Флаг успешности
+     * @param mixed  $body         Содержимое ответа ответа
+     * @param string $errorMessage Строка с описанием ошибки
+     * @param string $errorCode    Код ошибки в текстовом представлении
      *
      * @throws ErrorException
      */
-    private function __construct($isSuccess, $body, $error = null)
+    private function __construct($isSuccess, $body, $errorMessage = null, $errorCode = null)
     {
         if (!$this->isSerializable($body)) {
             throw new ErrorException(self::ERR__BODY_NOT_SERIALIZABLE);
         }
+
         $this->isSuccess = $isSuccess;
         $this->content = $body;
-        $this->error = $error;
+        $this->errorMessage = $errorMessage;
+        $this->errorCode = $errorCode;
     }
 
     /**
@@ -64,11 +75,13 @@ class Response
     {
         $isSerializable = true;
         $array = [$body];
-        array_walk_recursive($array, function ($e) use (&$isSerializable) {
-            if (is_object($e) && get_class($e) === 'Closure') {
-                $isSerializable = false;
-            }
-        });
+        array_walk_recursive(
+            $array,
+            function ($e) use (&$isSerializable) {
+                if (is_object($e) && get_class($e) === 'Closure') {
+                    $isSerializable = false;
+                }
+            });
 
         return $isSerializable;
     }
@@ -79,6 +92,7 @@ class Response
      * @param mixed $body Содержимое ответа
      *
      * @return Response
+     * @throws ErrorException
      */
     public static function success($body = null)
     {
@@ -88,14 +102,16 @@ class Response
     /**
      * Возвращает неуспешный результат
      *
-     * @param mixed  $body  Содержимое ответа
-     * @param string $error Строка с описанием ошибки
+     * @param mixed  $body         Содержимое ответа
+     * @param string $errorMessage Строка с описанием ошибки
+     * @param string $errorCode    Код ошибки в текстовом представлении
      *
      * @return Response
+     * @throws ErrorException
      */
-    public static function failure($body = null, $error = null)
+    public static function failure($body = null, $errorMessage = null, $errorCode = null)
     {
-        return new self(false, $body, $error);
+        return new self(false, $body, $errorMessage, $errorCode);
     }
 
     /**
@@ -125,6 +141,18 @@ class Response
      */
     public function getError()
     {
-        return $this->error;
+        return $this->errorMessage;
     }
+
+    /**
+     * Возвращает faultcode
+     *
+     * @return mixed
+     */
+    public function getErrorCode()
+    {
+        return $this->errorCode;
+    }
+
+
 }

--- a/src/ITMH/ServiceTools/Services/SoapService.php
+++ b/src/ITMH/ServiceTools/Services/SoapService.php
@@ -124,7 +124,7 @@ class SoapService extends Service
 
             return Response::success($raw);
         } catch (SoapFault $fault) {
-            return Response::failure(null, $fault->getMessage());
+            return Response::failure(null, $fault->getMessage(), $fault->faultcode);
         }
     }
 

--- a/tests/unit/ServiceTools/ServiceCacherConfigTest.php
+++ b/tests/unit/ServiceTools/ServiceCacherConfigTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Codeception\TestCase\Test;
-use ServiceTools\Core\Service;
+use ITMH\ServiceTools\Core\Service;
 use Stash\Driver\Ephemeral;
 use Stash\DriverList;
 use Stash\Interfaces\PoolInterface;
@@ -22,7 +22,7 @@ class ServiceCacherConfigTest extends Test
     }
 
     /**
-     * @return \ServiceTools\Core\Service|\PHPUnit_Framework_MockObject_MockObject
+     * @return \ITMH\ServiceTools\Core\Service|\PHPUnit_Framework_MockObject_MockObject
      */
     private function getMockService()
     {

--- a/tests/unit/ServiceTools/ServiceLoggerConfigTest.php
+++ b/tests/unit/ServiceTools/ServiceLoggerConfigTest.php
@@ -6,7 +6,7 @@ use Codeception\TestCase\Test;
 use Monolog\Handler\ErrorLogHandler;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
-use ServiceTools\Core\Service;
+use ITMH\ServiceTools\Core\Service;
 
 class ServiceLoggerConfigTest extends Test
 {
@@ -23,7 +23,7 @@ class ServiceLoggerConfigTest extends Test
     }
 
     /**
-     * @return \ServiceTools\Core\Service|\PHPUnit_Framework_MockObject_MockObject
+     * @return \ITMH\ServiceTools\Core\Service|\PHPUnit_Framework_MockObject_MockObject
      */
     private function getMockService()
     {

--- a/tests/unit/ServiceTools/ServiceTest.php
+++ b/tests/unit/ServiceTools/ServiceTest.php
@@ -2,10 +2,10 @@
 
 use Codeception\Specify;
 use Codeception\TestCase\Test;
-use ServiceTools\Core\ConfigurationErrorException;
-use ServiceTools\Core\Response;
-use ServiceTools\Core\Service;
-use ServiceTools\Helpers\Pinba;
+use ITMH\ServiceTools\Core\ConfigurationErrorException;
+use ITMH\ServiceTools\Core\Response;
+use ITMH\ServiceTools\Core\Service;
+use ITMH\ServiceTools\Helpers\Pinba;
 
 class CoreTest extends Test
 {
@@ -73,9 +73,11 @@ class CoreTest extends Test
     public function testResponseFailureHelper()
     {
         $failureResponseError = 'failure';
-        $failureResponse = Response::failure(null, $failureResponseError);
+        $failureResponseCode = 'InternalError';
+        $failureResponse = Response::failure(null, $failureResponseError, $failureResponseCode);
         self::assertFalse($failureResponse->isOk());
         self::assertNotNull($failureResponse->getError());
+        self::assertNotNull($failureResponse->getErrorCode());
     }
 
     public function testResponseCheckSerialization()

--- a/tests/unit/ServiceTools/ServiceTest.php
+++ b/tests/unit/ServiceTools/ServiceTest.php
@@ -99,7 +99,7 @@ class CoreTest extends Test
             ->method('isEnabled')
             ->willReturn(false);
 
-        $timer = $pinba->start('foo', 'bar');
+        $timer = $pinba->start(array('foo', 'bar'));
         self::assertNull($timer);
 
         $success = $pinba->stop($timer);

--- a/tests/unit/ServiceTools/SoapServiceTest.php
+++ b/tests/unit/ServiceTools/SoapServiceTest.php
@@ -2,9 +2,9 @@
 namespace ServiceTools;
 
 use Codeception\TestCase\Test;
-use ServiceTools\Core\ConfigurationErrorException;
-use ServiceTools\Core\Response;
-use ServiceTools\Services\SoapService;
+use ITMH\ServiceTools\Core\ConfigurationErrorException;
+use ITMH\ServiceTools\Core\Response;
+use ITMH\ServiceTools\Services\SoapService;
 
 class SoapServiceTest extends Test
 {


### PR DESCRIPTION
В класс Response поле $error заменено на $errorMessage;
Название геттера не изменено для обратной совместимости;
Добавлено поле $errorCode;
Добавлена передача faultcode в SoapService;
Неймспейсы в тестах заменены на правильные;
Дополнен тест testResponseFailureHelper.
